### PR TITLE
Removed the auto resize feature, call `redraw` when needed instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,6 @@ The page rotation in degrees, only multiple of 90 are valid.
 The scaling factor. By default, the pdf will be scaled to match the page width
 with the container width.
 
-#### :resize <sup>Boolean - default: false</sup>
-Enable Auto Resizing on window resize. By default, autoresizing is disabled.
-
 #### :annotation <sup>Boolean - default: false</sup>
 Show the annotations in the pdf. By default, annotation layer is disabled.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "pdfjs-dist": "^2.0.489",
     "raw-loader": "^0.5.1",
-    "vue-resize-sensor": "^2.0.0"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Call `redraw` from the parent component when needed (e.g. on window resize) and don't forget to debounce.