### PR TITLE
Set the default value of `scale` to 'page-width'

### DIFF
--- a/src/Pdfvuer.vue
+++ b/src/Pdfvuer.vue
@@ -92,7 +92,7 @@ export default {
 		},
 		scale: {
 			type: [Number, String],
-			default: 1,
+			default: 'page-width',
 		},
 		resize: {
 			type: Boolean,


### PR DESCRIPTION
Set the default value of `scale` to 'page-width' as mentioned in the readme
