### PR TITLE
Fix the version of pdfjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4194,6 +4194,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc="
+    },
     "node-forge": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
@@ -4609,16 +4614,19 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.5.207",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.5.207.tgz",
-      "integrity": "sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw=="
+      "version": "2.3.200",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.3.200.tgz",
+      "integrity": "sha512-+8wBjU5h8LPZOIvR9X2uCrp/8xWQG1DRDKMLg5lzGN1qyIAZlYUxA0KQyy12Nw5jN7ozulC6v97PMaDcLgAcFg==",
+      "requires": {
+        "node-ensure": "^0.0.0",
+        "worker-loader": "^2.0.0"
+      }
     },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -7028,7 +7036,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -7095,7 +7102,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
   },
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "pdfjs-dist": "^2.5.207",
-    "raw-loader": "^0.5.1",
-    "worker-loader": "^2.0.0"
+    "pdfjs-dist": "2.3.200",
+    "raw-loader": "^0.5.1"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Following on issues in customer app, I belive the reason for build issues is loosely specified pdfjs version. I'm not sure we can bump the version without updating this repo. So this PR fixes the version to latest working dependency. 

See her, where they dropped the dependency - https://github.com/mozilla/pdfjs-dist/commit/a3a0d672c2f3464e4bff95ad0a3b41341eb65a26#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

I've accidently opened a PR on the upstream repo. :D  https://github.com/arkokoley/pdfvuer/pull/61